### PR TITLE
Fix layout in frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: page
 title: Developer Experience and Community Success team handbook
 ---
 


### PR DESCRIPTION
The default layout seems to be `page`. Using `default` as a layout does not render a page.

Signed-off-by: David Planella <dplanella@linuxfoundation.org>