### PR TITLE
Create _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+title: Developer Experience and Community Success handbook
+description: Linux Foundations's Developer Experience and Community Success team handbook


### PR DESCRIPTION
Adds textual description to site name at the top of the handbook pages

Signed-off-by: David Planella <dplanella@linuxfoundation.org>