### PR TITLE
Make section a Header 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Content contribution in detail:
 
 :information_source: Note for advanced users: members of the [Developer Experience and Community Success team](https://github.com/orgs/linuxfoundation/teams/devex-and-commsuccess-team) in the `linuxfoundation` organization in GitHub can create development branches directly under the repository where the handbook lives. These will be generally the ones that will be used to contain the changes submitted in PRs. It is not the most common development approach, but it simplifies our workflow. Working on forks and topic branches is also supported.
 
-# Acronym Glossary
+## Acronym Glossary
 
 This is just a start. Please add any acronyms that your projects use! 
 


### PR DESCRIPTION
Convert section heading from `Header 1` to `Header 2` for consistency with the rest of the handbook.

Signed-off-by: David Planella <dplanella@linuxfoundation.org>